### PR TITLE
Fixed repl client/server biz

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,14 +6,13 @@ The [[https://github.com/ptaoussanis/sente/tree/master/example-project][example 
 ** Usage
 
 Fire the Boot pipeline from the command line.
-#+BEGIN_SRC shell
+```shell
 $ boot dev
-#+END_SRC
+```
 
-1. Connect to the REPL. 
-2. Type ~(start!)~ in the REPL.
+1. Connect to the with your favorite editor or run `boot repl-client` in a separate shell.
+2. Type `(start!)` in the REPL.
 3. Your browser should automatically open to the provided port on localhost
-4. Press Ctrl-C to exit logging and enter the REPl again
-5. Type ~(test-fast-server>user-pushes)~ in the REPL. And look at output of js console
+5. Type `(test-fast-server>user-pushes)` in the REPL. And look at output of js console.
 ** More
 Please also check out [[https://github.com/danielsz/sente-system][the example app for system]].

--- a/README.org
+++ b/README.org
@@ -10,7 +10,7 @@ Fire the Boot pipeline from the command line.
 $ boot dev
 #+END_SRC
 
-1. Connect to the REPL with your favorite editor or run `boot repl-client` in a separate shell.
+1. Connect to the REPL with your favorite editor or run ~boot repl-client~ in a separate shell.
 2. Type ~(start!)~ in the REPL.
 3. Your browser should automatically open to the provided port on localhost
 5. Type ~(test-fast-server>user-pushes)~ in the REPL. And look at output of js console

--- a/README.org
+++ b/README.org
@@ -6,13 +6,13 @@ The [[https://github.com/ptaoussanis/sente/tree/master/example-project][example 
 ** Usage
 
 Fire the Boot pipeline from the command line.
-```shell
+#+BEGIN_SRC shell
 $ boot dev
-```
+#+END_SRC
 
-1. Connect to the with your favorite editor or run `boot repl-client` in a separate shell.
-2. Type `(start!)` in the REPL.
+1. Connect to the REPL with your favorite editor or run `boot repl-client` in a separate shell.
+2. Type ~(start!)~ in the REPL.
 3. Your browser should automatically open to the provided port on localhost
-5. Type `(test-fast-server>user-pushes)` in the REPL. And look at output of js console.
+5. Type ~(test-fast-server>user-pushes)~ in the REPL. And look at output of js console
 ** More
 Please also check out [[https://github.com/danielsz/sente-system][the example app for system]].

--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (set-env!
  :source-paths   #{"src/clj" "src/cljs"}
- :dependencies '[[adzerk/boot-cljs      "0.0-3269-2" :scope "test"]
+ :dependencies '[[adzerk/boot-cljs      "2.0.0" :scope "test"]
                  [adzerk/boot-reload    "0.5.1"      :scope "test"]
                  [org.clojure/clojure       "1.7.0-RC1"]
                  [org.clojure/tools.nrepl "0.2.10"]
@@ -35,4 +35,11 @@
    (watch)
    (cljs :source-map true)
    (reload)
-   (repl :init-ns 'example.my-app)))
+   (repl 
+    :server true 
+    :init-ns 'example.my-app)))
+
+(deftask repl-client
+ []
+ (comp
+  (repl :client true)))


### PR DESCRIPTION
Realized dev task should have repl as server so reload works properly.
Added a new task called repl-client so you dont need emacs or protorepl to test.
Updated readme
Updated boot-cljs dep

